### PR TITLE
feat: add retro skill for structured session retrospectives

### DIFF
--- a/.claude/plan-test-architecture.md
+++ b/.claude/plan-test-architecture.md
@@ -15,8 +15,12 @@ No test suite exists. This plan sets up the minimum viable test infrastructure f
 ## Step 1: Install devDependencies
 
 ```bash
-npm install --save-dev vitest @vitejs/plugin-react @testing-library/react @testing-library/jest-dom jsdom
+npm install --save-dev vitest @vitejs/plugin-react @testing-library/react@latest @testing-library/jest-dom jsdom vite-tsconfig-paths
 ```
+
+Notes:
+- `@testing-library/react@latest` ensures React 19 compatibility
+- `vite-tsconfig-paths` reads path aliases directly from `tsconfig.json` (replaces manual `resolve.alias`)
 
 ---
 
@@ -24,9 +28,9 @@ npm install --save-dev vitest @vitejs/plugin-react @testing-library/react @testi
 
 Key settings:
 - `environment: 'jsdom'`
+- `globals: true` — removes the need to import `describe`/`it`/`expect` in every test file
 - `setupFiles: ['./src/test/setup.ts']`
-- `resolve.alias`: mirror `@/*` from `tsconfig.json`
-- Plugin: `@vitejs/plugin-react`
+- Plugin: `@vitejs/plugin-react` + `tsconfigPaths()` from `vite-tsconfig-paths`
 - Include: `src/**/*.test.{ts,tsx}`
 - Assets: handle `*.{png,jpg,svg}` stubs (static image imports in constants)
 
@@ -44,16 +48,19 @@ import '@testing-library/jest-dom'
 
 ```json
 "test": "vitest run",
-"test:watch": "vitest"
+"test:watch": "vitest",
+"test:coverage": "vitest run --coverage"
 ```
 
 ---
 
 ## Step 5: Write `src/lib/utils.test.ts`
 
-Test the `isMobile()` function — two cases:
+Test the `isMobile()` function — three cases:
+
 - Returns `true` when `window.innerWidth <= 1024`
 - Returns `false` when `window.innerWidth > 1024`
+- Returns `false` when `window` is undefined (SSR environment) — `isMobile()` already guards against this with `typeof window === 'undefined'`
 
 This is a pure function with no dependencies, making it the ideal first test to confirm the entire Vitest + jsdom pipeline is wired correctly.
 
@@ -72,7 +79,7 @@ This is a pure function with no dependencies, making it the ideal first test to 
 
 ## Verification
 
-Run `npm test` — should show 2 passing tests with no errors or warnings.
+Run `npm test` — should show 3 passing tests with no errors or warnings.
 
 ---
 
@@ -82,3 +89,4 @@ Once testing suite is set up, some ideas for what to add next:
 - Data integrity tests for `projects`, `navlinks`, `timeline` constants
 - Component tests for `Heading`, `Paragraph`, `Badge`, `WorkHistory`, `Sidebar`
 - Framer Motion mock setup at `src/test/mocks/framer-motion.ts`
+- `next/navigation` mocks (`useRouter`, `usePathname`) for component tests

--- a/.claude/plan-test-architecture.md
+++ b/.claude/plan-test-architecture.md
@@ -1,0 +1,84 @@
+# Plan: Add Test Architecture
+
+## Context
+
+No test suite exists. This plan sets up the minimum viable test infrastructure for the Next.js 15 + React 19 + TypeScript portfolio, then validates it works with a single unit test for `isMobile()`.
+
+## Scope
+
+1. Install dependencies
+2. Create config files
+3. Write ONE test (`utils.test.ts`) to confirm the pipeline works end-to-end
+
+---
+
+## Step 1: Install devDependencies
+
+```bash
+npm install --save-dev vitest @vitejs/plugin-react @testing-library/react @testing-library/jest-dom jsdom
+```
+
+---
+
+## Step 2: Create `vitest.config.ts` (project root)
+
+Key settings:
+- `environment: 'jsdom'`
+- `setupFiles: ['./src/test/setup.ts']`
+- `resolve.alias`: mirror `@/*` from `tsconfig.json`
+- Plugin: `@vitejs/plugin-react`
+- Include: `src/**/*.test.{ts,tsx}`
+- Assets: handle `*.{png,jpg,svg}` stubs (static image imports in constants)
+
+---
+
+## Step 3: Create `src/test/setup.ts`
+
+```ts
+import '@testing-library/jest-dom'
+```
+
+---
+
+## Step 4: Add npm scripts to `package.json`
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+---
+
+## Step 5: Write `src/lib/utils.test.ts`
+
+Test the `isMobile()` function — two cases:
+- Returns `true` when `window.innerWidth <= 1024`
+- Returns `false` when `window.innerWidth > 1024`
+
+This is a pure function with no dependencies, making it the ideal first test to confirm the entire Vitest + jsdom pipeline is wired correctly.
+
+---
+
+## Files to Create/Modify
+
+| File | Action |
+|---|---|
+| `vitest.config.ts` | Create |
+| `src/test/setup.ts` | Create |
+| `src/lib/utils.test.ts` | Create |
+| `package.json` | Edit — add test scripts |
+
+---
+
+## Verification
+
+Run `npm test` — should show 2 passing tests with no errors or warnings.
+
+---
+
+## Future Tests (out of scope for this PR)
+
+Once testing suite is set up, some ideas for what to add next:
+- Data integrity tests for `projects`, `navlinks`, `timeline` constants
+- Component tests for `Heading`, `Paragraph`, `Badge`, `WorkHistory`, `Sidebar`
+- Framer Motion mock setup at `src/test/mocks/framer-motion.ts`

--- a/.claude/retros/2026-04-14-14-07.md
+++ b/.claude/retros/2026-04-14-14-07.md
@@ -1,0 +1,47 @@
+# Session Retro — 2026-04-14
+
+## What Went Well
+
+- **Reading the implementation before accepting feedback.** Before updating the plan, I checked the actual `isMobile()` source. This revealed the SSR `typeof window` guard was already in place — which meant Gemini's "blocker #1" was a non-issue for the utility itself, but surfaced a valid missing test case. Without reading the code, we'd have either ignored a real gap or accepted a false blocker uncritically.
+- **Distinguishing valid vs out-of-scope feedback.** Both Gemini responses included CI integration and `next/navigation` mocks. Rather than adding everything, we filtered by scope (MVP setup only) and deferred appropriately to the Future Tests list. The plan stayed focused.
+- **Cross-checking with two independent Gemini reviews.** The user ran their own separate Gemini query in parallel. Both flagged `vite-tsconfig-paths` and React 19 compat — high-signal agreement on the most important changes.
+- **Saving the workflow preference to memory immediately** after the user expressed it, without needing to be asked twice.
+
+## What Went Wrong
+
+- **First Gemini prompt was rejected.** The initial prompt lacked tone guidance — it didn't tell Gemini to be concise and practical, and didn't describe the project as a simple portfolio site. The user had to stop and correct this before the tool call ran.
+- **Background task output read too early.** After running the Gemini command in background, I read the output file before it had finished writing — got an empty file, then checked file size, causing unnecessary noise before the task notification came in.
+- **Attempted a synchronous retry while background was still running.** Rather than waiting for the task notification, I tried to re-run the command synchronously. The user interrupted this. I should have trusted the background task and waited.
+
+## Time Wasted
+
+- ~3–5 minutes on the Gemini prompt iteration (rejected first attempt, had to rewrite)
+- ~2 minutes on the premature output file reads and the aborted synchronous retry
+
+## Root Causes
+
+- **No established prompt template for Gemini plan reviews.** There's no script or skill that encodes the right framing (concise, practical, describe the tech stack, scope clearly). Each time this is done manually from scratch — which means iteration.
+- **Background task read pattern is unclear.** I didn't wait for the task completion notification before reading the output file. The correct pattern is: run in background → wait for notification → then read. This isn't encoded anywhere.
+
+## Changes to Make
+
+### CLAUDE.md Updates
+
+No changes needed — the Gemini review workflow is a process pattern, not project-specific context.
+
+### New Skills to Create
+
+**`gemini-review`**
+- **Name:** `gemini-review`
+- **Description:** Sends a plan or document to the Gemini CLI for a concise second-opinion review. Encodes the right prompt framing (practical, scoped to project type, no over-engineering). Use before finalising any architecture or implementation plan.
+- **What it encodes:** The prompt template — tone instructions, project context injection, structured output request (issues/improvements/missing/verdict). Prevents the prompt iteration that happened this session.
+
+### Scripts to Write
+
+**`scripts/review-plan.sh <plan-file>`**
+Wraps the Gemini CLI call with the standard review prompt template. Takes a plan file path as argument, injects the content, and outputs Gemini's feedback. This is the automation the user asked for — the manual step that should eventually be hooked into plan finalisation automatically.
+
+### Other Actions
+
+- **Hook (deferred, user confirmed for later):** Wire up a `PostToolUse` hook on plan file writes to automatically trigger `scripts/review-plan.sh`. User acknowledged this and chose to do it later via `/update-config`.
+- **Background task pattern:** When using `run_in_background`, do not read the output file until the task completion notification arrives. Trust the notification.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: retro
+description: Use when the user asks for a retrospective, session review, or wants to capture what went well, what went wrong, and what should change after a working session
+---
+
+# Retro
+
+## Overview
+
+Reviews the current conversation session and produces a structured retrospective as a markdown file. Identifies patterns, waste, root causes, and concrete next actions — so lessons are captured and acted on, not forgotten.
+
+## When to Use
+
+- User says `/retro`, "let's do a retro", "review this session", or "what should we change"
+- End of a meaningful working session
+- After a frustrating session where things went wrong
+- After a session that went unusually well and the approach should be repeated
+
+**NOT for:** Mid-task pauses, simple Q&A sessions with no meaningful arc
+
+## Output File
+
+Write the retrospective to:
+```
+.claude/retros/YYYY-MM-DD-HH-MM.md
+```
+
+Use the current date/time. Create the `retros/` directory if it doesn't exist. Confirm the file path to the user after writing.
+
+## Retrospective Structure
+
+```markdown
+# Session Retro — YYYY-MM-DD
+
+## What Went Well
+[Techniques, decisions, or interactions that produced good outcomes — be specific]
+
+## What Went Wrong
+[Mistakes, misunderstandings, wrong turns — be honest, not diplomatic]
+
+## Time Wasted
+[Specific things that burned time without producing value, with rough estimates if possible]
+
+## Root Causes
+[The underlying WHY behind what went wrong — not symptoms, actual causes]
+
+## Changes to Make
+
+### CLAUDE.md Updates
+[Specific additions or edits to CLAUDE.md that would prevent these issues — include the proposed text]
+
+### New Skills to Create
+[Skill ideas: name, description, what it would encode]
+
+### Scripts to Write
+[Automation ideas: what manual step was repeated or error-prone]
+
+### Other Actions
+[Anything that doesn't fit above: memory updates, config changes, process changes]
+```
+
+## Analysis Guidelines
+
+**Scan the full conversation for:**
+- Repeated back-and-forth on the same point (misalignment, missing context)
+- Tool calls that failed, were retried, or took multiple attempts (brittleness)
+- Moments the user corrected direction (wrong assumptions, over-engineering)
+- Long stretches without user interaction (may signal lost context or going in circles)
+- Things the user praised or confirmed as exactly right (repeat these)
+
+**Root causes to probe:**
+- Was information missing from CLAUDE.md?
+- Was there a skill that should have existed?
+- Was context lost mid-session?
+- Did Claude over-engineer, under-read, or skip a step?
+- Was a manual step done repeatedly that could be automated?
+
+**What a good retro surfaces:**
+- Prompts that consistently fail → rewrite them or encode them in a skill
+- Tasks you did more than twice → should be a skill
+- Context that was missing → add it to CLAUDE.md
+- Handoff gaps → fix the memory or artifact pattern
+- Time sinks → automate with a script
+
+**Changes section — be specific:**
+- For CLAUDE.md: propose the exact text to add/change, not just "add something about X"
+- For new skills: give a draft `name` and `description` field, not just a topic
+- For scripts: describe the exact manual action being automated
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Writing vague "went well" items like "communication was good" | Name the specific technique or decision: "Reading the file before editing it prevented a destructive overwrite" |
+| Listing symptoms as root causes | Ask *why* — if tests failed, why did they fail? Missing context? Wrong assumption? |
+| Proposing CLAUDE.md changes without text | Always include the exact proposed text so the user can accept it immediately |
+| Skipping the Changes section because "it was fine" | Even good sessions have at least one thing to capture — if truly nothing, say so explicitly |
+| Writing the retro as a narrative | Use the structured sections — they're easier to act on |

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 - [ ] add github links to project pages
 - [ ] add db and schema to replace client side data
 - [ ] complete blog page layout
-- [ ] write first blog
+- [x] write first blog
 - [ ] add resume/work experiences page
 - [ ] investigate github live integration
-- [ ] add my strengths cards to my about page using Aceternity focus cards: https://ui.aceternity.com/components/focus-cards
 - [ ] add call to actions to my about page
 - [ ] extract stack list to a component (in project and timeline components)
 


### PR DESCRIPTION
## Summary

- Adds a `/retro` skill that guides structured post-session retrospectives (what went well, what went wrong, what to change)
- Retrospective outputs are saved as markdown files under `.claude/retros/` with timestamped filenames
- Includes first usage as test, a review of the test architecture plan: session retro from 2026-04-14

## Changes

- `.claude/skills/retro/SKILL.md` — new retro skill definition
- `.claude/retros/2026-04-14-14-07.md` — first retro generated with the skill
- `.claude/plan-test-architecture.md` — test architecture plan (v2, cross-checked with Gemini CLI)
- `README.md` — minor update

## Test plan

- [x] Run `/retro` at the end of a session and verify the skill prompts for reflection and saves output to `.claude/retros/`
- [x] Confirm the generated retro file follows the expected structure (date, sections, action items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)